### PR TITLE
Remove failing request-termination plugin

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-  - name: request-termination
     config:
       status_code: 503
       message: '"Service is now unavailable"'

--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-    config:
       status_code: 503
       message: '"Service is now unavailable"'
 services:

--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-      status_code: 503
       message: '"Service is now unavailable"'
 services:
   - name: echo-service

--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-      message: '"Service is now unavailable"'
 services:
   - name: echo-service
     path: /anything


### PR DESCRIPTION
Remove request-termination plugin causing 100% error rate

- Identified route 'echo-route' experiencing 100% failure rate (503 errors)
- Global request-termination plugin was terminating ALL requests with 503 status  
- Plugin was affecting all traffic to /echo endpoint
- Total requests analyzed: 131 errors in last 15 minutes, 0 successful requests